### PR TITLE
test: 로컬주소에서 test하기 위해 REDIRECT_URI를 로컬주소로 변경

### DIFF
--- a/src/Pages/LoginPage/kakao/kakaoLoginData.ts
+++ b/src/Pages/LoginPage/kakao/kakaoLoginData.ts
@@ -1,2 +1,2 @@
 export const REST_API_KEY = '09a22e956a2a5c4e19defdcc56606a2e'
-export const REDIRECT_URI = 'https://mysolverfrontend.vercel.app/signup/detail'
+export const REDIRECT_URI = 'http://localhost:5173/signup/detail'


### PR DESCRIPTION
## Motivations ��

- vercel 배포 시, 404 오류를 해결했기 때문에 다시 로컬 주소로 변경
  <br/>
  ​

## key Changes ⭐️

- ​test: 로컬주소에서 test하기 위해 REDIRECT_URI를 로컬주소로 변경
- 추후에 로컬주소와 배포주소를 같이 쓸 수 있는지 알아보기
  <br/>
  ​

## To Reviewers ��

- ​
  <br/>
