### PR TITLE
feat: signupdetailpage의  react-daum-postcode 추가(지도 검색 창), 전화번호 입력창 삭제

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.4.0",
         "dnd-core": "^16.0.1",
         "react": "^18.2.0",
+        "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.2.0",
         "react-icons": "^4.10.1",
         "react-router-dom": "^6.14.1",
@@ -4410,6 +4411,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-daum-postcode": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz",
+      "integrity": "sha512-qTyzUb1BeszPFO4FXSj6p83Wrn5Zpo6YqI2EZ46XSVRZT+du9CrKg9p3KshBRFKYxXmFE1Mv7wEynzXdRFNlmQ==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dnd": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.4.0",
     "dnd-core": "^16.0.1",
     "react": "^18.2.0",
+    "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.2.0",
     "react-icons": "^4.10.1",
     "react-router-dom": "^6.14.1",

--- a/src/Pages/SignpDetailPage/SignupDetailPage.tsx
+++ b/src/Pages/SignpDetailPage/SignupDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
-import { Container, InputBox, Title, Box, EmailInputBox, EmailInput, EmailCheckBtn, Alertment, PhonenumberInput, MapBox, UserLastBtn} from './styled'
-import MapComponent from './MapComponent';
+import { Container, InputBox, Title, Box, PostBox, Alertment, UserLastBtn, NicknameCheckBtn, NicknameInput, NicknameInputBox, LocationBtn, LocationMent, LocationBox} from './styled'
+import DaumPostcode from "react-daum-postcode";
 
 declare global {
   interface Window {
@@ -13,11 +13,6 @@ const SignupDetailPage: React.FC = () => {
   const [nickName, setNickname] = useState<string>('');
   const [nicknameAlert, setNicknameAlert] = useState<string>('');
   const [isNickName, setIsNickname] = useState<boolean>(false);
-
-  // 전화번호
-  const [phonenumber, setphonenumber] = useState<string>('');
-  const [phonenumberAlert, setphonenumberAlert] = useState<string>('');
-  const [isphoneNumber, setIsphoneNumber] = useState<boolean>(false);
 
   //닉네임
   const onCheckingNickname = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -34,21 +29,6 @@ const SignupDetailPage: React.FC = () => {
     }
   }, [])
 
-  //전화번호
-  const onCheckingPhoneNumber = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const phonenumberRegex = /^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$/;
-    const phonenumberCurrent = e.target.value;
-    setphonenumber(phonenumberCurrent);
-
-    if (!phonenumberRegex.test(phonenumberCurrent)) {
-      setphonenumberAlert('-를 포함하여 작성해주세요.');
-      setIsphoneNumber(false);
-    } else {
-      setphonenumberAlert('올바른 전화번호 형식입니다.');
-      setIsphoneNumber(true);
-    }
-  }, [])
-
   // 카카오 로그인해서 넘어온 사람의 이메일을 가지고 
   // 닉네임, 전화번호, 지도 위치 추가로 저장
   // console.log(kakaoUserDoc) // 카카오 로그인한 사용자 정보
@@ -58,16 +38,28 @@ const SignupDetailPage: React.FC = () => {
   // sessionStorage.setItem('user', `${kakouserID}`)
 
   const setingUser = () => {
-    // 닉네임, 전화번호 입력했는지? 
-    // 지도 위치 받아야 함
-    // 닉네임, 전화번호,지도 위치 -> db에 저장
-    if(isNickName === true && isphoneNumber === true) {
+    // 닉네임, 도로명 + 위도경도 -> db에 저장
+    if(isNickName === true) {
       // 모달창 변경
       alert('회원가입에 성공하셨습니다.')
       window.location.href = '/'
     } else {
       alert('정보를 입력해주세요.')
     }
+  }
+
+  const [visible, setVisible] = useState<boolean>(false)
+  // 도로명 주소
+  const [userLocation, setUserLocation] = useState<string>('버튼을 눌러 주소를 설정해주세요!')
+
+  const onCompletePost = (data: { address: any; }) => {
+    // 주소
+    console.log(data.address)
+    setUserLocation(data.address)
+  }
+
+  const addressStyle = {
+    height: "100%",
   }
 
 
@@ -77,29 +69,36 @@ const SignupDetailPage: React.FC = () => {
         <Title>세부정보 등록</Title>
 
         <Box className="textcolor">
-          <EmailInputBox>
-            <EmailInput placeholder='닉네임' type="text"
+          <NicknameInputBox>
+            <NicknameInput placeholder='닉네임' type="text"
               onChange={onCheckingNickname}/>
-            <EmailCheckBtn>중복검사</EmailCheckBtn> 
-          </EmailInputBox>
+            <NicknameCheckBtn>중복검사</NicknameCheckBtn> 
+          </NicknameInputBox>
           {nickName.length > 0 && 
             <Alertment className={`message ${isNickName ? 'success' : 'error'}`}>{nicknameAlert}</Alertment>
           }
         </Box>
 
-        <Box className="textcolor">
-          <PhonenumberInput placeholder='전화번호' type="text"
-            onChange={onCheckingPhoneNumber}/>
-          {phonenumber.length > 0 && 
-            <Alertment className={`message ${isphoneNumber ? 'success' : 'error'}`}>{phonenumberAlert}</Alertment>
+        <LocationBox>
+          {
+            visible &&
+            <PostBox>
+              <DaumPostcode
+                onComplete={onCompletePost}
+                style={addressStyle}
+              />
+            </PostBox>
           }
-        </Box>
+          <LocationMent>{userLocation}</LocationMent>
+          <LocationBtn onClick={() => {
+            setVisible(true)}}>도로명 주소 검색</LocationBtn>
+        </LocationBox>
 
-        <MapBox>
+        {/* <MapBox>
           <MapComponent mapCenter={{ lat: 33.450701, lon: 126.570667 }} />
-        </MapBox>
+        </MapBox> */}
         
-        {/* 닉네임, 전화번호, 위치 User DB 에 저장 
+        {/* 닉네임, 위치 User DB 에 저장 
           메인페이지로 가는 임시 버튼 */}
         <UserLastBtn onClick={setingUser}>현재 위치로 등록</UserLastBtn>
       </InputBox>

--- a/src/Pages/SignpDetailPage/styled.ts
+++ b/src/Pages/SignpDetailPage/styled.ts
@@ -29,12 +29,12 @@ export const Box = styled.div`
   }
 `
 
-export const EmailInputBox = styled.div`
+export const NicknameInputBox = styled.div`
   display: flex;
   align-items: baseline;
   width: 100%;
 `
-export const EmailInput = styled.input`
+export const NicknameInput = styled.input`
   width: 70%;
   margin: 6px 0;
   padding: 8px;
@@ -51,7 +51,7 @@ export const Alertment = styled.span`
   padding-left: 8px;
 `
 
-export const EmailCheckBtn = styled.button`
+export const NicknameCheckBtn = styled.button`
   margin-left: 8px;
   padding: 10px;
   border-radius: 8px;
@@ -64,21 +64,10 @@ export const EmailCheckBtn = styled.button`
   font-weight: 500;
 `
 
-export const PhonenumberInput = styled.input`
-  width: 95%;
-  margin: 6px 0;
-  padding: 8px;
-  border-radius: 12px;
-  border: 0;
-
-  background-color: #F5F5F5;
-
-  outline: none;
-`
 
 export const UserLastBtn = styled.button`
   width: 85%;
-  margin: 0 auto;
+  margin-top: 260px;
   padding: 10px;
   border-radius: 6px;
   border: 0;
@@ -92,17 +81,61 @@ export const UserLastBtn = styled.button`
   cursor: pointer;
 `
 
-export const MapBox = styled.div`
-  width: 280px;
-  height: 250px;
-  margin: 15px 0;
-  background-color: white;
+// export const MapBox = styled.div`
+//   width: 280px;
+//   height: 250px;
+//   margin: 15px 0;
+//   background-color: white;
 
+//   display: flex;
+//   justify-content: center;
+// `
+
+// export const MapContainer = styled.div`
+//   width: 100%;
+//   height: 100%;
+// `
+
+export const LocationBox = styled.div`
+  position: relative;
+  width: 85%;
+  margin: 10px 0;
   display: flex;
-  justify-content: center;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 6px;
+  background-color: #F5F5F5;
+`
+export const LocationMent =  styled.span`
+  margin: 0 8px;
+  font-size: 12px;
+
+  overflow: scroll;
+  overflow: auto;
+  white-space: nowrap;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+`
+export const PostBox =  styled.div`
+  width: 100%;
+  height: 300px;
+  position: absolute;
+  top: 0;
+  z-index: 1;
 `
 
-export const MapContainer = styled.div`
-  width: 100%;
+export const LocationBtn = styled.button`
+  width: 40%;
   height: 100%;
+  margin: 10px;
+  padding: 5px 0;
+  border: 0;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 700;
+  background-color: #fff;
+
+  cursor: pointer;  
 `


### PR DESCRIPTION
## Motivations ��

- ​ signupdetailpage 페이지에서 전화번호 입력을 받지 않고 주소를 받아와야 함
  <br/>
  ​

## key Changes ⭐️

- ​지도를 빼고 react-daum-postcode를 사용하여 지도 검색 창 추가했다. 따라서 도로명 주소를 얻을 수 있음. 위도와 경도 구하는 것도 추가 예정
  <br/>
  ​

## To Reviewers ��

- ​
  <br/>
