### PR TITLE
feat: 관심글 추가, 삭제, 조회 기능(recoil)

### DIFF
--- a/src/Pages/API/axiosAPI.tsx
+++ b/src/Pages/API/axiosAPI.tsx
@@ -63,6 +63,10 @@ instanceHeader.interceptors.response.use(
     if (response.data.profileImage === null && response.data.streetNameAddress === '') {
       window.location.href = '/signup/detail'
     }
+    if(response.headers.location) {
+      window.location.href = `${response.headers.location}`
+    }
+    console.log(response.headers.location)
     return response.data
   },
   error => {

--- a/src/Pages/MyPageLikeListPage/MyPageLikeListPage.tsx
+++ b/src/Pages/MyPageLikeListPage/MyPageLikeListPage.tsx
@@ -2,10 +2,13 @@ import { Link } from "react-router-dom"
 import { BiArrowBack, BiConfused } from 'react-icons/bi'
 import { SC } from './styled'
 import { instanceHeader } from "../API/axiosAPI"
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
+import { useRecoilState } from "recoil"
+import { likelist } from "../../recoil/atoms"
 
 export default function MyPageLikeListPage() {
-const [list, setList] = useState<any>([])
+const [ListALL, setListALL] = useRecoilState<any>(likelist)
+
   const interestsList = () => {
     try {
       instanceHeader({
@@ -13,8 +16,7 @@ const [list, setList] = useState<any>([])
         method: 'get',
       })
       .then((res) => {
-        console.log(res)
-        setList(res)
+        setListALL(res)
       })
     } catch (error: any) {
       console.log(error)
@@ -25,6 +27,23 @@ const [list, setList] = useState<any>([])
     interestsList()
   }, [])
 
+  const ondelete = (productid: any) => {
+    console.log(productid)
+    try {
+      instanceHeader({
+        url: `users/interests/${productid}`,
+        method: 'delete',
+      })
+      .then((res) => {
+        setListALL(res)
+        console.log('삭제되었습니다')
+      })
+    } catch (error: any) {
+      console.log(error)
+    }
+  }
+
+
   return (
     <SC.Container>
       <SC.BackBtn onClick={() => history.back()}>
@@ -33,22 +52,24 @@ const [list, setList] = useState<any>([])
       <SC.Title>관심글 목록</SC.Title>
       <SC.ListBox>
         {
-          list.length !== 0 
+          ListALL.length !== 0 
           ?
-          list.map((product: any, index: any) => {
+          ListALL.map((product: any, index: number) => {
             return (
-              <Link to='/view' style={{ textDecoration: "none", color: "#000"}}>
-                <SC.LikeCard key={index}>
+              <Link to={`/errand/${product.errandId}`} key={`${index}_${product.errandId}`} style={{ textDecoration: "none", color: "#000"}}>
+                <SC.LikeCard >
                   <SC.ImgBox>
-                  {/* 이미지 받아오기 */}
                     <SC.Img src="https://images.mypetlife.co.kr/content/uploads/2023/02/03094318/AdobeStock_366413112-1024x682.jpeg"/>
                   </SC.ImgBox>
                   <SC.DoscBox>
-                    <SC.DoscTitle>{product.errandTitle ? product.errandTitle : '관심글이 없습니다.'}</SC.DoscTitle>
+                    <SC.DoscTitle>{product.errandTitle}</SC.DoscTitle>
                     <SC.HashtagMent>#강아지 #산책</SC.HashtagMent>
                     <SC.MoneyMent>
                       시급 10,000원
-                      <SC.DeleteBtn>X</SC.DeleteBtn>
+                      <SC.DeleteBtn onClick={(e:any) => {
+                        e.preventDefault()
+                        ondelete(`${product.errandId}`)
+                      }}>X</SC.DeleteBtn>
                     </SC.MoneyMent>
                   </SC.DoscBox>
                 </SC.LikeCard>

--- a/src/Pages/ViewPage/ViewPage.tsx
+++ b/src/Pages/ViewPage/ViewPage.tsx
@@ -1,8 +1,8 @@
 import ReactDOM from 'react-dom';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { useEffect, useState } from 'react'
 import { BsHeart, BsHeartFill} from 'react-icons/bs';
-import { isDeleteState } from '../../recoil/atoms';
+import { isDeleteState, likelist } from '../../recoil/atoms';
 import { SC } from './styled.ts'
 import { useParams } from 'react-router-dom';
 import { instanceHeader } from '../API/axiosAPI.tsx';
@@ -29,6 +29,7 @@ export const ViewPage = () => {
     const [, setIsLoading] = useState<boolean | null>(false);
     const [isLike, setIsLike] = useState<boolean>(false);
     const [, setIsDelete] = useRecoilState<boolean>(isDeleteState);
+    const setListALL = useSetRecoilState<any>(likelist)
   
     useEffect(() => {
       const fetchData = () => {
@@ -49,8 +50,46 @@ export const ViewPage = () => {
       },[id])
 
 
+    // 관심글 추가
+    const interestsPut = () => {
+      try {
+        instanceHeader({
+          url: `users/interests/${id}`,
+          method: 'put'
+        }).then((res: any) => {
+          console.log(res)
+          setListALL(res)
+          console.log('추가되었습니다')
+        })
+      } catch (error) {
+        console.log(error)
+      }
+    }
+
+    // 관심글 삭제
+    const interestDelete = () => {
+      try {
+        instanceHeader({
+          url: `users/interests/${id}`,
+          method: 'delete',
+        })
+        .then((res) => {
+          console.log(res)
+          setListALL(res)
+          console.log('삭제되었습니다')
+        })
+      } catch (error: any) {
+        console.log(error)
+      }
+    }
+
     const handleLike = () => {
       setIsLike(!isLike)
+      if(isLike) {
+        interestDelete()
+      } else {
+        interestsPut()
+      }
     }
 
 
@@ -89,8 +128,8 @@ export const ViewPage = () => {
             </SC.ContentBox>
             <SC.MoreBox>
                 {
-                  isLike ? <BsHeart size={30} onClick={handleLike} style={{ color: 'red', cursor: 'pointer'}} /> 
-                  : <BsHeartFill size={30} onClick={handleLike} style={{ color: 'red', cursor: 'pointer'}} />
+                  isLike ? <BsHeartFill size={30} onClick={handleLike} style={{ color: 'red', cursor: 'pointer'}} />
+                  : <BsHeart size={30} onClick={handleLike} style={{ color: 'red', cursor: 'pointer'}} />
                 }
                 <SC.PaymentCondition>{`${itemData?.payDivision}${itemData?.pay}`}</SC.PaymentCondition>
                 <SC.ChattingButton>채팅하기</SC.ChattingButton>

--- a/src/recoil/atoms.tsx
+++ b/src/recoil/atoms.tsx
@@ -16,3 +16,8 @@ export const mapCenterState = atom<{lat: number, lon: number} | null>({
   key: 'mapCenter',
   default: null
 })
+
+export const likelist = atom<any>({
+  key:'likelist',
+  default: [],
+})


### PR DESCRIPTION
## Motivations ��
- ​의뢰 글에서 좋아요를 누르면 관심글 목록에 추가되고, 다시 한 번 누르면 삭제가 된다. 관심글 목록은 recoil로 관리되어 마이페이지의 관심글 목록에서 확인할 수 있으며 목록에서도 삭제가 가능하다.
  <br/>
  ​

## key Changes ⭐️
- recoil를 사용했기 때문에 관심글 목록을 새로고침 하지 않아도 자동적으로 리렌더링된 것처럼 보인다​
  <br/>
  ​

## To Reviewers ��

- ​
  <br/>
