### PR TITLE
fix: 관심글 목록에서 해당 관심글로 이동하는 Link 태그 수정

### DIFF
--- a/src/Pages/MyPageLikeListPage/MyPageLikeListPage.tsx
+++ b/src/Pages/MyPageLikeListPage/MyPageLikeListPage.tsx
@@ -55,8 +55,9 @@ const [ListALL, setListALL] = useRecoilState<any>(likelist)
           ListALL.length !== 0 
           ?
           ListALL.map((product: any, index: number) => {
+            console.log(typeof product.errandId)
             return (
-              <Link to={`/errand/${product.errandId}`} key={`${index}_${product.errandId}`} style={{ textDecoration: "none", color: "#000"}}>
+              <Link to={`/errands/${product.errandId}`} key={`${index}_${product.errandId}`} style={{ textDecoration: "none", color: "#000"}}>
                 <SC.LikeCard>
                   <SC.DoscBox>
                     <SC.DoscTitle>{product.errandTitle}</SC.DoscTitle>

--- a/src/Pages/ReviewErranderPage/ReviewErranderPage.tsx
+++ b/src/Pages/ReviewErranderPage/ReviewErranderPage.tsx
@@ -46,6 +46,11 @@ export default function ReviewErranderPage() {
     alert('평가 완료')
   }
 
+
+  // 이 둘을 보내주면 됨
+  // reviewValue -> 좋아요, 보통이에요, 아쉬워요 중에 고른 해당 평가에 대한 점수
+  // detailreviewValue -> 아쉬웠다면?에서 고른 평가 코멘트 s
+
   return (
     <SC.Container>
       <SC.Title>의뢰인 평가</SC.Title>
@@ -54,15 +59,15 @@ export default function ReviewErranderPage() {
           <FcBusinessman size={66}/>
         </SC.IconBox>
         <SC.CheckBoxCnt>
-            <input type="checkbox" id="좋아요" name="fristcheckWrap" value="좋아요"
+            <input type="checkbox" id="좋아요" name="fristcheckWrap" value="5"
              onClick={CheckReview} />
             <label htmlFor="좋아요">좋아요</label>
 
-            <input type="checkbox" id="보통이에요" name="fristcheckWrap" value="보통이에요"
+            <input type="checkbox" id="보통이에요" name="fristcheckWrap" value="3"
               onClick={CheckReview}  />
             <label htmlFor="보통이에요">보통이에요</label>
 
-            <input type="checkbox" id="아쉬워요" name="fristcheckWrap" value="아쉬워요" 
+            <input type="checkbox" id="아쉬워요" name="fristcheckWrap" value="1" 
               onClick={CheckReview}  />
             <label htmlFor="아쉬워요">아쉬워요</label>
         </SC.CheckBoxCnt>


### PR DESCRIPTION
## Motivations ��

- ​관심글 목록에서 해당 제목을 클릭하면 해당 글로 이동하도록 구현했는데 링크 주소에 오타가 있어 수정했다.
  <br/>
  ​

## key Changes ⭐️

- ​해당 의뢰 페이지로 이동
  <br/>
  ​

## To Reviewers ��

- ​
  <br/>
